### PR TITLE
Add lib_compat_mode to work with latest platformio

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -30,6 +30,7 @@ build_flags =
 	-DARDUINO_USB_CDC_ON_BOOT=1
 	-DARDUINO_USB_MODE=1
 	-DESP32_S3_DEVKITM_1
+lib_compat_mode=strict
 
 [env:esp32dev]
 platform = espressif32
@@ -47,3 +48,4 @@ platform_packages=
   framework-arduinoespressif32-libs @ https://github.com/espressif/arduino-esp32/releases/download/3.0.2/esp32-arduino-libs-3.0.2.zip
 build_flags =
 	-DESP32DEV
+lib_compat_mode=strict


### PR DESCRIPTION
The latest version of platform.io doesn't compile without the lib_compat_mode=strict setting.

I'm using Version: Core 6.1.18·Home 3.4.4